### PR TITLE
fix: make the account id optional when getting plans

### DIFF
--- a/billing-functions/src/billing-functions-wrapper.ts
+++ b/billing-functions/src/billing-functions-wrapper.ts
@@ -1,207 +1,212 @@
-import {Database as BASEJUMP_DATABASE_SCHEMA} from "../types/basejump-database.ts";
-import {requireAuthorizedBillingUser} from "./require-authorized-billing-user.ts";
+import { Database as BASEJUMP_DATABASE_SCHEMA } from "../types/basejump-database.ts";
+import { requireAuthorizedBillingUser } from "./require-authorized-billing-user.ts";
 import getBillingStatus from "./wrappers/get-billing-status.ts";
 import createSupabaseServiceClient from "../lib/create-supabase-service-client.ts";
-import {corsHeaders} from "../lib/cors-headers.ts";
-import {BASEJUMP_BILLING_DATA_UPSERT} from "../lib/upsert-data.ts";
+import { corsHeaders } from "../lib/cors-headers.ts";
+import { BASEJUMP_BILLING_DATA_UPSERT } from "../lib/upsert-data.ts";
 import validateUrl from "../lib/validate-url.ts";
 import errorResponse from "../lib/error-response.ts";
 
 type GET_PLANS_ARGS = {
-    account_id?: string;
+  account_id?: string;
 };
 
 type GET_PLANS_RESPONSE = Array<{
-    id: string;
-    name: string;
-    description?: string;
-    amount: number;
-    currency: string;
-    interval: "month" | "year" | "one_time";
-    interval_count: 1;
-    trial_period_days?: 30;
-    active?: boolean;
-    metadata?: {
-        [key: string]: string;
-    };
+  id: string;
+  name: string;
+  description?: string;
+  amount: number;
+  currency: string;
+  interval: "month" | "year" | "one_time";
+  interval_count: 1;
+  trial_period_days?: 30;
+  active?: boolean;
+  metadata?: {
+    [key: string]: string;
+  };
 }>;
 
 type GET_BILLING_PORTAL_URL_ARGS = {
-    accountId: string;
-    subscriptionId: string;
-    customerId?: string;
-    returnUrl: string;
+  accountId: string;
+  subscriptionId: string;
+  customerId?: string;
+  returnUrl: string;
 };
 
 type GET_NEW_SUBSCRIPTION_URL_ARGS = {
-    accountId: string;
-    planId: string;
-    successUrl: string;
-    cancelUrl: string;
-    billingEmail: string;
-    customerId?: string;
+  accountId: string;
+  planId: string;
+  successUrl: string;
+  cancelUrl: string;
+  billingEmail: string;
+  customerId?: string;
 };
 
 type GET_BILLING_STATUS_ARGS = {
-    accountId: string;
-    billingEmail?: string;
-    defaultPlanId?: string;
-    defaultTrialDays?: number;
-    customerId?: string;
-    subscriptionId?: string;
+  accountId: string;
+  billingEmail?: string;
+  defaultPlanId?: string;
+  defaultTrialDays?: number;
+  customerId?: string;
+  subscriptionId?: string;
 };
 
 type GENERIC_URL_RESPONSE = {
-    url: string;
+  url: string;
 };
 
 export type GET_BILLING_STATUS_RESPONSE = {
-    subscription_id: string;
-    subscription_active: boolean;
-    status: BASEJUMP_DATABASE_SCHEMA["basejump"]["Tables"]["billing_subscriptions"]["Row"]["status"];
-    billing_email?: string;
-    account_role: BASEJUMP_DATABASE_SCHEMA["basejump"]["Tables"]["account_user"]["Row"]["account_role"];
-    is_primary_owner: boolean;
-    billing_enabled: boolean;
+  subscription_id: string;
+  subscription_active: boolean;
+  status: BASEJUMP_DATABASE_SCHEMA["basejump"]["Tables"]["billing_subscriptions"]["Row"]["status"];
+  billing_email?: string;
+  account_role: BASEJUMP_DATABASE_SCHEMA["basejump"]["Tables"]["account_user"]["Row"]["account_role"];
+  is_primary_owner: boolean;
+  billing_enabled: boolean;
+  plan_name?: string;
+  metadata?: any;
 };
 
 type BILLING_FUNCTION_WRAPPER_OPTIONS = {
-    allowedURLs: Array<string>;
-}
+  allowedURLs: Array<string>;
+};
 
 export type BILLING_FUNCTION_WRAPPER_HANDLERS = {
-    provider: BASEJUMP_DATABASE_SCHEMA["basejump"]["Tables"]["billing_subscriptions"]["Row"]["provider"];
-    getPlans: (args: GET_PLANS_ARGS) => Promise<GET_PLANS_RESPONSE>;
-    getBillingPortalUrl: (
-        args: GET_BILLING_PORTAL_URL_ARGS
-    ) => Promise<GENERIC_URL_RESPONSE>;
-    getNewSubscriptionUrl: (
-        args: GET_NEW_SUBSCRIPTION_URL_ARGS
-    ) => Promise<GENERIC_URL_RESPONSE>;
-    getBillingStatus: (
-        args: GET_BILLING_STATUS_ARGS
-    ) => Promise<BASEJUMP_BILLING_DATA_UPSERT>;
+  provider: BASEJUMP_DATABASE_SCHEMA["basejump"]["Tables"]["billing_subscriptions"]["Row"]["provider"];
+  getPlans: (args: GET_PLANS_ARGS) => Promise<GET_PLANS_RESPONSE>;
+  getBillingPortalUrl: (
+    args: GET_BILLING_PORTAL_URL_ARGS,
+  ) => Promise<GENERIC_URL_RESPONSE>;
+  getNewSubscriptionUrl: (
+    args: GET_NEW_SUBSCRIPTION_URL_ARGS,
+  ) => Promise<GENERIC_URL_RESPONSE>;
+  getBillingStatus: (
+    args: GET_BILLING_STATUS_ARGS,
+  ) => Promise<BASEJUMP_BILLING_DATA_UPSERT>;
 };
 
 export function billingFunctionsWrapper(
-    handlers: BILLING_FUNCTION_WRAPPER_HANDLERS,
-    options: BILLING_FUNCTION_WRAPPER_OPTIONS = {
-        allowedURLs: [],
-    }
+  handlers: BILLING_FUNCTION_WRAPPER_HANDLERS,
+  options: BILLING_FUNCTION_WRAPPER_OPTIONS = {
+    allowedURLs: [],
+  },
 ): (req: Request) => Promise<Response> {
-    return async function (req: Request) {
-        // check for options preflight and handle cors
-        if (req.method === "OPTIONS") {
-            return new Response("ok", {headers: corsHeaders});
-        }
-        const body = await req.json();
+  return async function (req: Request) {
+    // check for options preflight and handle cors
+    if (req.method === "OPTIONS") {
+      return new Response("ok", { headers: corsHeaders });
+    }
+    const body = await req.json();
 
-        if (body.action !== "get_plans" && !body.args?.account_id) {
-            return errorResponse("Account id is required");
-        }
-        try {
-            switch (body.action) {
-                case "get_plans":
-                    const plans = await handlers.getPlans(body.args);
-                    return new Response(JSON.stringify(plans), {
-                        headers: {
-                            ...corsHeaders,
-                            "Content-Type": "application/json",
-                        },
-                    });
-                case "get_billing_portal_url":
-                    if (!validateUrl(body.args.return_url, options.allowedURLs)) {
-                        return errorResponse("Return url is not allowed");
-                    }
-                    return await requireAuthorizedBillingUser(req, {
-                        accountId: body.args.account_id,
-                        authorizedRoles: ["owner"],
-                        async onBillableAndAuthorized(roleInfo) {
-                            const response = await handlers.getBillingPortalUrl({
-                                accountId: roleInfo.account_id,
-                                subscriptionId: roleInfo.billing_subscription_id,
-                                customerId: roleInfo.billing_customer_id,
-                                returnUrl: body.args.return_url,
-                            });
-                            return new Response(
-                                JSON.stringify({
-                                    billing_enabled: roleInfo.billing_enabled,
-                                    ...response,
-                                }),
-                                {
-                                    headers: {
-                                        ...corsHeaders,
-                                        "Content-Type": "application/json",
-                                    },
-                                }
-                            );
-                        },
-                    });
-                case "get_new_subscription_url":
-                    if (!validateUrl(body.args.success_url, options.allowedURLs) || !validateUrl(body.args.cancel_url, options.allowedURLs)) {
-                        return errorResponse("Success or cancel url is not allowed");
-                    }
-                    return await requireAuthorizedBillingUser(req, {
-                        accountId: body.args.account_id,
-                        authorizedRoles: ["owner"],
-                        async onBillableAndAuthorized(roleInfo) {
-                            const response = await handlers.getNewSubscriptionUrl({
-                                accountId: roleInfo.account_id,
-                                planId: body.args.plan_id,
-                                successUrl: body.args.success_url,
-                                cancelUrl: body.args.cancel_url,
-                                billingEmail: roleInfo.billing_email,
-                                customerId: roleInfo.billing_customer_id,
-                            });
-                            return new Response(
-                                JSON.stringify({
-                                    billing_enabled: roleInfo.billing_enabled,
-                                    ...response,
-                                }),
-                                {
-                                    headers: {
-                                        ...corsHeaders,
-                                        "Content-Type": "application/json",
-                                    },
-                                }
-                            );
-                        },
-                    });
+    if (body.action !== "get_plans" && !body.args?.account_id) {
+      return errorResponse("Account id is required");
+    }
+    try {
+      switch (body.action) {
+        case "get_plans":
+          const plans = await handlers.getPlans(body.args);
+          return new Response(JSON.stringify(plans), {
+            headers: {
+              ...corsHeaders,
+              "Content-Type": "application/json",
+            },
+          });
+        case "get_billing_portal_url":
+          if (!validateUrl(body.args.return_url, options.allowedURLs)) {
+            return errorResponse("Return url is not allowed");
+          }
+          return await requireAuthorizedBillingUser(req, {
+            accountId: body.args.account_id,
+            authorizedRoles: ["owner"],
+            async onBillableAndAuthorized(roleInfo) {
+              const response = await handlers.getBillingPortalUrl({
+                accountId: roleInfo.account_id,
+                subscriptionId: roleInfo.billing_subscription_id,
+                customerId: roleInfo.billing_customer_id,
+                returnUrl: body.args.return_url,
+              });
+              return new Response(
+                JSON.stringify({
+                  billing_enabled: roleInfo.billing_enabled,
+                  ...response,
+                }),
+                {
+                  headers: {
+                    ...corsHeaders,
+                    "Content-Type": "application/json",
+                  },
+                },
+              );
+            },
+          });
+        case "get_new_subscription_url":
+          if (
+            !validateUrl(body.args.success_url, options.allowedURLs) ||
+            !validateUrl(body.args.cancel_url, options.allowedURLs)
+          ) {
+            return errorResponse("Success or cancel url is not allowed");
+          }
+          return await requireAuthorizedBillingUser(req, {
+            accountId: body.args.account_id,
+            authorizedRoles: ["owner"],
+            async onBillableAndAuthorized(roleInfo) {
+              const response = await handlers.getNewSubscriptionUrl({
+                accountId: roleInfo.account_id,
+                planId: body.args.plan_id,
+                successUrl: body.args.success_url,
+                cancelUrl: body.args.cancel_url,
+                billingEmail: roleInfo.billing_email,
+                customerId: roleInfo.billing_customer_id,
+              });
+              return new Response(
+                JSON.stringify({
+                  billing_enabled: roleInfo.billing_enabled,
+                  ...response,
+                }),
+                {
+                  headers: {
+                    ...corsHeaders,
+                    "Content-Type": "application/json",
+                  },
+                },
+              );
+            },
+          });
 
-                case "get_billing_status":
-                    return await requireAuthorizedBillingUser(req, {
-                        accountId: body.args.account_id,
-                        authorizedRoles: ["owner"],
-                        async onBillableAndAuthorized(roleInfo) {
-                            const supabaseClient = createSupabaseServiceClient();
-                            const response = await getBillingStatus(
-                                supabaseClient,
-                                roleInfo,
-                                handlers
-                            );
+        case "get_billing_status":
+          return await requireAuthorizedBillingUser(req, {
+            accountId: body.args.account_id,
+            authorizedRoles: ["owner"],
+            async onBillableAndAuthorized(roleInfo) {
+              const supabaseClient = createSupabaseServiceClient();
+              const response = await getBillingStatus(
+                supabaseClient,
+                roleInfo,
+                handlers,
+              );
 
-                            return new Response(
-                                JSON.stringify({
-                                    ...response,
-                                    status: response.status || "not_setup",
-                                    billing_enabled: roleInfo.billing_enabled,
-                                }),
-                                {
-                                    headers: {
-                                        ...corsHeaders,
-                                        "Content-Type": "application/json",
-                                    },
-                                }
-                            );
-                        },
-                    });
+              return new Response(
+                JSON.stringify({
+                  ...response,
+                  status: response.status || "not_setup",
+                  billing_enabled: roleInfo.billing_enabled,
+                }),
+                {
+                  headers: {
+                    ...corsHeaders,
+                    "Content-Type": "application/json",
+                  },
+                },
+              );
+            },
+          });
 
-                default:
-                    return errorResponse("Invalid action");
-            }
-        } catch (e) {
-            console.log(e);
-            return errorResponse("Internal server error", 500);
-        }
-    };
+        default:
+          return errorResponse("Invalid action");
+      }
+    } catch (e) {
+      console.log(e);
+      return errorResponse("Internal server error", 500);
+    }
+  };
 }

--- a/billing-functions/src/billing-functions-wrapper.ts
+++ b/billing-functions/src/billing-functions-wrapper.ts
@@ -96,7 +96,7 @@ export function billingFunctionsWrapper(
         }
         const body = await req.json();
 
-        if (!body.args?.account_id) {
+        if (body.action !== "get_plans" && !body.args?.account_id) {
             return errorResponse("Account id is required");
         }
         try {

--- a/billing-functions/src/providers/stripe/billing-functions/get-plans.ts
+++ b/billing-functions/src/providers/stripe/billing-functions/get-plans.ts
@@ -1,6 +1,7 @@
 export default async function getPlans(stripeClient) {
   const prices = await stripeClient.prices.list({
     expand: ["data.product"],
+    active: true,
   });
 
   return prices?.data?.map((price: Stripe.Price) => {

--- a/billing-functions/src/providers/stripe/billing-functions/get-plans.ts
+++ b/billing-functions/src/providers/stripe/billing-functions/get-plans.ts
@@ -12,6 +12,7 @@ export default async function getPlans(stripeClient) {
       id: price.id,
       interval:
         price.type === "one_time" ? "one_time" : price.recurring?.interval,
+      metadata: price.metadata
     };
   });
 }

--- a/billing-functions/src/providers/stripe/billing-functions/stripe-utils.ts
+++ b/billing-functions/src/providers/stripe/billing-functions/stripe-utils.ts
@@ -23,10 +23,10 @@ export function stripeSubscriptionToBasejumpSubscription(
 ): BASEJUMP_BILLING_DATA_UPSERT["subscription"] {
   return {
     id: subscription.id,
-    plan_name: subscription.plan_name,
+    plan_name: subscription.items.data[0].plan.nickname,
     account_id: accountId,
     billing_customer_id: subscription.customer,
-    metadata: subscription.metadata,
+    metadata: subscription.items.data[0].plan.metadata,
     status: subscription.status,
     price_id: subscription.items.data[0].price.id,
     quantity: subscription.items.data[0].quantity,

--- a/billing-functions/src/providers/stripe/billing-functions/stripe-utils.ts
+++ b/billing-functions/src/providers/stripe/billing-functions/stripe-utils.ts
@@ -7,7 +7,7 @@ function unixToIso(unixTime: number) {
 
 export function stripeCustomerToBasejumpCustomer(
   accountId: string,
-  stripeCustomer: Stripe.Customer
+  stripeCustomer: Stripe.Customer,
 ): BASEJUMP_BILLING_DATA_UPSERT["customer"] {
   return {
     id: stripeCustomer.id,
@@ -19,10 +19,11 @@ export function stripeCustomerToBasejumpCustomer(
 
 export function stripeSubscriptionToBasejumpSubscription(
   accountId: string,
-  subscription: Stripe.Subscription
+  subscription: Stripe.Subscription,
 ): BASEJUMP_BILLING_DATA_UPSERT["subscription"] {
   return {
     id: subscription.id,
+    plan_name: subscription.plan_name,
     account_id: accountId,
     billing_customer_id: subscription.customer,
     metadata: subscription.metadata,
@@ -37,7 +38,7 @@ export function stripeSubscriptionToBasejumpSubscription(
       ? unixToIso(subscription.canceled_at)
       : null,
     current_period_start: new Date(
-      subscription.current_period_start
+      subscription.current_period_start,
     ).toISOString(),
     current_period_end: unixToIso(subscription.current_period_end),
     created: unixToIso(subscription.created),

--- a/billing-functions/src/require-authorized-billing-user.ts
+++ b/billing-functions/src/require-authorized-billing-user.ts
@@ -1,99 +1,100 @@
 import createSupabaseClient from "../lib/create-supabase-client.ts";
-import {Database as BASEJUMP_DATABASE_SCHEMA} from "../types/basejump-database.ts";
+import { Database as BASEJUMP_DATABASE_SCHEMA } from "../types/basejump-database.ts";
 import errorResponse from "../lib/error-response.ts";
 
 export type AUTHORIZED_BILLING_USER_INFO = {
-    account_role: BASEJUMP_DATABASE_SCHEMA["basejump"]["Tables"]["account_user"]["Row"]["account_role"];
-    is_primary_owner: boolean;
-    is_personal_account: boolean;
-    account_id: string;
-    billing_subscription_id: string;
-    billing_status: string;
-    billing_customer_id: string;
-    billing_email: string;
-    billing_enabled: boolean;
-    billing_provider?: string;
+  account_role: BASEJUMP_DATABASE_SCHEMA["basejump"]["Tables"]["account_user"]["Row"]["account_role"];
+  is_primary_owner: boolean;
+  is_personal_account: boolean;
+  account_id: string;
+  billing_subscription_id: string;
+  billing_status: string;
+  billing_customer_id: string;
+  billing_email: string;
+  billing_enabled: boolean;
+  billing_provider?: string;
 };
 
 type REQUIRE_AUTHORIZED_BILLING_USER_OPTIONS = {
-    accountId: string;
-    authorizedRoles: string[];
-    onBillingDisabled?: () => Promise<Response>;
-    onUnauthorized?: () => Promise<Response>;
-    onBillableAndAuthorized?: (
-        roleInfo: AUTHORIZED_BILLING_USER_INFO
-    ) => Promise<Response>;
-    onError?: (e: Error) => Promise<Response>;
+  accountId: string;
+  authorizedRoles: string[];
+  onBillingDisabled?: () => Promise<Response>;
+  onUnauthorized?: () => Promise<Response>;
+  onBillableAndAuthorized?: (
+    roleInfo: AUTHORIZED_BILLING_USER_INFO,
+  ) => Promise<Response>;
+  onError?: (e: Error) => Promise<Response>;
 };
 
 export async function requireAuthorizedBillingUser(
-    req: Request,
-    options: REQUIRE_AUTHORIZED_BILLING_USER_OPTIONS
+  req: Request,
+  options: REQUIRE_AUTHORIZED_BILLING_USER_OPTIONS,
 ): Promise<Response> {
-    try {
-        const authToken = req.headers.get("Authorization");
-        const accountId = options.accountId;
-        // we don't have what we need. instant block.
-        if (!authToken || !accountId) {
-            if (options.onUnauthorized) {
-                return await options.onUnauthorized();
-            }
-            return errorResponse("Unauthorized", 401);
-        }
-
-
-        const supabase = createSupabaseClient(authToken);
-        const {data, error} = await supabase.rpc("get_account_billing_status", {
-            account_id: options.accountId,
-        }) as {data: AUTHORIZED_BILLING_USER_INFO | null; error: any};
-
-
-
-        // means this user isn't a member of this account, block
-        if (!data || error) {
-            if (options.onUnauthorized) {
-                return await options.onUnauthorized();
-            }
-            return errorResponse("Unauthorized", 401);
-        }
-
-        // means this user is a member of this account, but not the right role, block
-        if (!options.authorizedRoles.includes(data.account_role)) {
-            if (options.onUnauthorized) {
-                return await options.onUnauthorized();
-            }
-            return errorResponse("Unauthorized", 401);
-        }
-
-        // means this user is a member of this account, but billing is disabled, just return a generic response
-        if (!data.billing_enabled) {
-            if (options.onBillingDisabled) {
-                return await options.onBillingDisabled();
-            }
-            return new Response(
-                JSON.stringify({
-                    billing_enabled: false,
-                }),
-                {
-                    headers: {
-                        "Content-Type": "application/json",
-                    },
-                }
-            );
-        }
-
-        if (!options.onBillableAndAuthorized) {
-            return errorResponse("Config error: No onBillableAndAuthorized function passed in", 400);
-        }
-
-        // means this user is a member of this account, and has the right role, allow
-        return await options.onBillableAndAuthorized?.(data);
-    } catch (e) {
-        // something went wrong, throw an error
-        if (options.onError) {
-            return options.onError(e);
-        } else {
-            return errorResponse("Internal Error", 500);
-        }
+  try {
+    const authToken = req.headers.get("Authorization");
+    const accountId = options.accountId;
+    // we don't have what we need. instant block.
+    if (!authToken || !accountId) {
+      if (options.onUnauthorized) {
+        return await options.onUnauthorized();
+      }
+      return errorResponse("Unauthorized", 401);
     }
+
+    const supabase = createSupabaseClient(authToken);
+    const { data, error } = (await supabase.rpc("get_account_billing_status", {
+      account_id: options.accountId,
+    })) as { data: AUTHORIZED_BILLING_USER_INFO | null; error: any };
+
+    // means this user isn't a member of this account, block
+    if (!data || error) {
+      if (options.onUnauthorized) {
+        return await options.onUnauthorized();
+      }
+      return errorResponse("Unauthorized", 401);
+    }
+
+    // means this user is a member of this account, but not the right role, block
+    if (!options.authorizedRoles.includes(data.account_role)) {
+      if (options.onUnauthorized) {
+        return await options.onUnauthorized();
+      }
+      return errorResponse("Unauthorized", 401);
+    }
+
+    // means this user is a member of this account, but billing is disabled, just return a generic response
+    if (!data.billing_enabled) {
+      if (options.onBillingDisabled) {
+        return await options.onBillingDisabled();
+      }
+      return new Response(
+        JSON.stringify({
+          billing_enabled: false,
+        }),
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      );
+    }
+
+    if (!options.onBillableAndAuthorized) {
+      return errorResponse(
+        "Config error: No onBillableAndAuthorized function passed in",
+        400,
+      );
+    }
+
+    // means this user is a member of this account, and has the right role, allow
+    return await options.onBillableAndAuthorized?.(data);
+  } catch (e) {
+    console.log(e);
+    // something went wrong, throw an error
+    if (options.onError) {
+      return options.onError(e);
+    } else {
+      return errorResponse("Internal Error", 500);
+    }
+  }
 }

--- a/billing-functions/src/wrappers/get-billing-status.ts
+++ b/billing-functions/src/wrappers/get-billing-status.ts
@@ -45,5 +45,7 @@ export default async function getBillingStatus(
     is_primary_owner: roleInfo.is_primary_owner,
     billing_enabled: roleInfo.billing_enabled,
     metadata: billingData?.subscription?.metadata,
+    raw_data: billingData,
+    raw_upsert_data: data,
   };
 }

--- a/billing-functions/src/wrappers/get-billing-status.ts
+++ b/billing-functions/src/wrappers/get-billing-status.ts
@@ -1,4 +1,4 @@
-import { SupabaseClient } from "@supabase/supabase-js";
+import {SupabaseClient} from "jsr:@supabase/supabase-js@2";
 import { AUTHORIZED_BILLING_USER_INFO } from "../require-authorized-billing-user.ts";
 import {
   BILLING_FUNCTION_WRAPPER_HANDLERS,

--- a/billing-functions/src/wrappers/get-billing-status.ts
+++ b/billing-functions/src/wrappers/get-billing-status.ts
@@ -44,5 +44,6 @@ export default async function getBillingStatus(
     account_role: roleInfo.account_role,
     is_primary_owner: roleInfo.is_primary_owner,
     billing_enabled: roleInfo.billing_enabled,
+    metadata: billingData?.subscription?.metadata,
   };
 }

--- a/billing-functions/src/wrappers/get-billing-status.ts
+++ b/billing-functions/src/wrappers/get-billing-status.ts
@@ -1,7 +1,10 @@
-import {SupabaseClient} from "@supabase/supabase-js";
-import {AUTHORIZED_BILLING_USER_INFO} from "../require-authorized-billing-user.ts";
-import {BILLING_FUNCTION_WRAPPER_HANDLERS, GET_BILLING_STATUS_RESPONSE,} from "../billing-functions-wrapper.ts";
-import {upsertCustomerSubscription} from "../../lib/upsert-data.ts";
+import { SupabaseClient } from "@supabase/supabase-js";
+import { AUTHORIZED_BILLING_USER_INFO } from "../require-authorized-billing-user.ts";
+import {
+  BILLING_FUNCTION_WRAPPER_HANDLERS,
+  GET_BILLING_STATUS_RESPONSE,
+} from "../billing-functions-wrapper.ts";
+import { upsertCustomerSubscription } from "../../lib/upsert-data.ts";
 
 /**
  * Responsible for handling the local data cache update for billing status
@@ -11,33 +14,35 @@ import {upsertCustomerSubscription} from "../../lib/upsert-data.ts";
  * @param handlers
  */
 export default async function getBillingStatus(
-    supabaseClient: SupabaseClient,
-    roleInfo: AUTHORIZED_BILLING_USER_INFO,
-    handlers: BILLING_FUNCTION_WRAPPER_HANDLERS
+  supabaseClient: SupabaseClient,
+  roleInfo: AUTHORIZED_BILLING_USER_INFO,
+  handlers: BILLING_FUNCTION_WRAPPER_HANDLERS,
 ): Promise<GET_BILLING_STATUS_RESPONSE> {
-    const billingData = await handlers.getBillingStatus({
-        accountId: roleInfo.account_id,
-        billingEmail: roleInfo.billing_email,
-        customerId: roleInfo.billing_customer_id,
-        subscriptionId: roleInfo.billing_subscription_id,
-    });
+  const billingData = await handlers.getBillingStatus({
+    accountId: roleInfo.account_id,
+    billingEmail: roleInfo.billing_email,
+    customerId: roleInfo.billing_customer_id,
+    subscriptionId: roleInfo.billing_subscription_id,
+  });
 
-    const data = await upsertCustomerSubscription(
-        supabaseClient,
-        roleInfo.account_id,
-        billingData
-    );
+  const data = await upsertCustomerSubscription(
+    supabaseClient,
+    roleInfo.account_id,
+    billingData,
+  );
 
-    return {
-        subscription_id: billingData?.subscription?.id,
-        plan_name: billingData?.subscription?.plan_name,
-        subscription_active: ["trialing", "active"].includes(
-            billingData?.subscription?.status
-        ),
-        status: billingData?.subscription?.status,
-        billing_email: billingData?.customer?.billing_email,
-        account_role: roleInfo.account_role,
-        is_primary_owner: roleInfo.is_primary_owner,
-        billing_enabled: roleInfo.billing_enabled,
-    };
+  console.log(billingData);
+
+  return {
+    subscription_id: billingData?.subscription?.id,
+    plan_name: billingData?.subscription?.plan_name,
+    subscription_active: ["trialing", "active"].includes(
+      billingData?.subscription?.status,
+    ),
+    status: billingData?.subscription?.status,
+    billing_email: billingData?.customer?.billing_email,
+    account_role: roleInfo.account_role,
+    is_primary_owner: roleInfo.is_primary_owner,
+    billing_enabled: roleInfo.billing_enabled,
+  };
 }


### PR DESCRIPTION
This means that a user doesn't need to be logged in to view plans.
The docs for this endpoint describe the account_id being optional but sending null or not providing this argument causes an error to be thrown. https://usebasejump.com/docs/billing#get-plans